### PR TITLE
feat: add automatic dashboard icons for agents based on model provider

### DIFF
--- a/chart/templates/03-agents.yaml
+++ b/chart/templates/03-agents.yaml
@@ -8,12 +8,8 @@ metadata:
   labels:
     {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
   annotations:
-    {{- if or (contains "claude" .model) (contains "anthropic" .model) }}
-    ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
-    {{- else if or (contains "gemini" .model) (contains "google" .model) }}
-    ark.mckinsey.com/dashboard-icon: "/icons/gemini.png"
-    {{- else if eq .model "default" }}
-    ark.mckinsey.com/dashboard-icon: "/icons/azure.png"
+    {{- if .dashboardIcon }}
+    ark.mckinsey.com/dashboard-icon: {{ .dashboardIcon | quote }}
     {{- end }}
 spec:
   {{- if eq .model "default" }}

--- a/chart/templates/03-agents.yaml
+++ b/chart/templates/03-agents.yaml
@@ -7,6 +7,14 @@ metadata:
   name: {{ .name }}
   labels:
     {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
+  annotations:
+    {{- if or (contains "claude" .model) (contains "anthropic" .model) }}
+    ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
+    {{- else if or (contains "gemini" .model) (contains "google" .model) }}
+    ark.mckinsey.com/dashboard-icon: "/icons/gemini.png"
+    {{- else if eq .model "default" }}
+    ark.mckinsey.com/dashboard-icon: "/icons/azure.png"
+    {{- end }}
 spec:
   {{- if eq .model "default" }}
   # Uses default model configured in the system

--- a/values.yaml
+++ b/values.yaml
@@ -44,11 +44,13 @@ models:
 agents:
   - name: planner
     model: claude-3-5-haiku  # Use Anthropic's Claude Haiku instead of default
+    dashboardIcon: "/icons/claude.png"
     description: |
       I'm a planning specialist who helps break down complex tasks into manageable steps and create actionable plans.
   
   - name: code-reviewer
     model: claude-4-opus  # Use Anthropic's Claude 4 Opus for advanced code review
+    dashboardIcon: "/icons/claude.png"
     description: |
       I'm a code review specialist who helps improve code quality, identifies issues, and suggests improvements.
 


### PR DESCRIPTION
## Summary
- Add automatic dashboard icon detection for agents based on their model
- Claude agents (claude-3-5-haiku, claude-4-opus) get Claude icons
- Gemini agents get Gemini icons
- Default/Azure agents get Azure icons
- Uses smart model name detection to assign appropriate provider icons