### PR TITLE
feat: Add GitHub MCP server and agent with comprehensive tools

### DIFF
--- a/chart/templates/01-secrets.yaml
+++ b/chart/templates/01-secrets.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.models.anthropic.enabled }}
+{{- if not .Values.models.anthropic.apiKey }}
+{{- fail "Anthropic models are enabled but apiKey is not set" }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -14,6 +17,9 @@ data:
 {{- end }}
 
 {{- if .Values.models.gemini.enabled }}
+{{- if not .Values.models.gemini.apiKey }}
+{{- fail "Gemini models are enabled but apiKey is not set" }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -28,7 +34,10 @@ data:
   apiKey: {{ .Values.models.gemini.apiKey | b64enc | quote }}
 {{- end }}
 
-{{- if and .Values.models.azureOpenAI.enabled .Values.models.azureOpenAI.baseUrl }}
+{{- if .Values.models.azureOpenAI.enabled }}
+{{- if not .Values.models.azureOpenAI.apiKey }}
+{{- fail "Azure OpenAI models are enabled but apiKey is not set" }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -42,6 +51,9 @@ data:
 {{- end }}
 
 {{- if .Values.models.openai.enabled }}
+{{- if not .Values.models.openai.apiKey }}
+{{- fail "OpenAI models are enabled but apiKey is not set" }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/chart/templates/03-agents.yaml
+++ b/chart/templates/03-agents.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.agents }}
 {{- range .Values.agents }}
+{{- if or (not (hasKey . "enabled")) .enabled }}
 ---
 apiVersion: ark.mckinsey.com/v1alpha1
 kind: Agent
@@ -20,5 +21,6 @@ spec:
   {{- end }}
   prompt: |
 {{ .description | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/github-mcp-agent/agent.yaml
+++ b/chart/templates/github-mcp-agent/agent.yaml
@@ -1,0 +1,205 @@
+{{- if and .Values.mcpServers.github.enabled .Values.mcpServers.github.agent.enabled }}
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: {{ .Values.mcpServers.github.agent.name }}
+  labels:
+    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.mcpServers.github.agent.dashboardIcon }}
+    ark.mckinsey.com/dashboard-icon: {{ .Values.mcpServers.github.agent.dashboardIcon | quote }}
+    {{- end }}
+spec:
+  {{- if eq .Values.mcpServers.github.agent.model "default" }}
+  # Uses default model configured in the system
+  {{- else }}
+  modelRef:
+    name: {{ .Values.mcpServers.github.agent.model }}
+  {{- end }}
+  tools:
+    - name: github-add-comment-to-pending-review
+      type: custom
+    - name: github-add-issue-comment
+      type: custom
+    - name: github-add-sub-issue
+      type: custom
+    - name: github-assign-copilot-to-issue
+      type: custom
+    - name: github-cancel-workflow-run
+      type: custom
+    - name: github-create-and-submit-pull-request-review
+      type: custom
+    - name: github-create-branch
+      type: custom
+    - name: github-create-gist
+      type: custom
+    - name: github-create-issue
+      type: custom
+    - name: github-create-or-update-file
+      type: custom
+    - name: github-create-pending-pull-request-review
+      type: custom
+    - name: github-create-pull-request
+      type: custom
+    - name: github-create-pull-request-with-copilot
+      type: custom
+    - name: github-create-repository
+      type: custom
+    - name: github-delete-file
+      type: custom
+    - name: github-delete-pending-pull-request-review
+      type: custom
+    - name: github-delete-workflow-run-logs
+      type: custom
+    - name: github-dismiss-notification
+      type: custom
+    - name: github-download-workflow-run-artifact
+      type: custom
+    - name: github-fork-repository
+      type: custom
+    - name: github-get-code-scanning-alert
+      type: custom
+    - name: github-get-commit
+      type: custom
+    - name: github-get-dependabot-alert
+      type: custom
+    - name: github-get-discussion
+      type: custom
+    - name: github-get-discussion-comments
+      type: custom
+    - name: github-get-file-contents
+      type: custom
+    - name: github-get-global-security-advisory
+      type: custom
+    - name: github-get-issue
+      type: custom
+    - name: github-get-issue-comments
+      type: custom
+    - name: github-get-job-logs
+      type: custom
+    - name: github-get-latest-release
+      type: custom
+    - name: github-get-me
+      type: custom
+    - name: github-get-notification-details
+      type: custom
+    - name: github-get-pull-request
+      type: custom
+    - name: github-get-pull-request-comments
+      type: custom
+    - name: github-get-pull-request-diff
+      type: custom
+    - name: github-get-pull-request-files
+      type: custom
+    - name: github-get-pull-request-reviews
+      type: custom
+    - name: github-get-pull-request-status
+      type: custom
+    - name: github-get-release-by-tag
+      type: custom
+    - name: github-get-secret-scanning-alert
+      type: custom
+    - name: github-get-tag
+      type: custom
+    - name: github-get-team-members
+      type: custom
+    - name: github-get-teams
+      type: custom
+    - name: github-get-workflow-run
+      type: custom
+    - name: github-get-workflow-run-logs
+      type: custom
+    - name: github-get-workflow-run-usage
+      type: custom
+    - name: github-list-branches
+      type: custom
+    - name: github-list-code-scanning-alerts
+      type: custom
+    - name: github-list-commits
+      type: custom
+    - name: github-list-dependabot-alerts
+      type: custom
+    - name: github-list-discussion-categories
+      type: custom
+    - name: github-list-discussions
+      type: custom
+    - name: github-list-gists
+      type: custom
+    - name: github-list-global-security-advisories
+      type: custom
+    - name: github-list-issue-types
+      type: custom
+    - name: github-list-issues
+      type: custom
+    - name: github-list-notifications
+      type: custom
+    - name: github-list-org-repository-security-advisories
+      type: custom
+    - name: github-list-pull-requests
+      type: custom
+    - name: github-list-releases
+      type: custom
+    - name: github-list-repository-security-advisories
+      type: custom
+    - name: github-list-secret-scanning-alerts
+      type: custom
+    - name: github-list-sub-issues
+      type: custom
+    - name: github-list-tags
+      type: custom
+    - name: github-list-workflow-jobs
+      type: custom
+    - name: github-list-workflow-run-artifacts
+      type: custom
+    - name: github-list-workflow-runs
+      type: custom
+    - name: github-list-workflows
+      type: custom
+    - name: github-manage-notification-subscription
+      type: custom
+    - name: github-manage-repository-notification-subscription
+      type: custom
+    - name: github-mark-all-notifications-read
+      type: custom
+    - name: github-merge-pull-request
+      type: custom
+    - name: github-push-files
+      type: custom
+    - name: github-remove-sub-issue
+      type: custom
+    - name: github-reprioritize-sub-issue
+      type: custom
+    - name: github-request-copilot-review
+      type: custom
+    - name: github-rerun-failed-jobs
+      type: custom
+    - name: github-rerun-workflow-run
+      type: custom
+    - name: github-run-workflow
+      type: custom
+    - name: github-search-code
+      type: custom
+    - name: github-search-issues
+      type: custom
+    - name: github-search-orgs
+      type: custom
+    - name: github-search-pull-requests
+      type: custom
+    - name: github-search-repositories
+      type: custom
+    - name: github-search-users
+      type: custom
+    - name: github-submit-pending-pull-request-review
+      type: custom
+    - name: github-update-gist
+      type: custom
+    - name: github-update-issue
+      type: custom
+    - name: github-update-pull-request
+      type: custom
+    - name: github-update-pull-request-branch
+      type: custom
+  prompt: |
+{{ .Values.mcpServers.github.agent.description | nindent 4 }}
+{{- end }}

--- a/chart/templates/github-mcp-agent/mcp-server.yaml
+++ b/chart/templates/github-mcp-agent/mcp-server.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.mcpServers.github.enabled }}
+{{- $githubToken := .Values.mcpServers.github.githubToken }}
+{{- if not $githubToken }}
+{{- fail "GitHub MCP server is enabled but GITHUB_TOKEN environment variable is not set" }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+  labels:
+    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+type: Opaque
+data:
+  token: {{ $githubToken | b64enc }}
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: github
+  labels:
+    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+spec:
+  address:
+    value: "https://api.githubcopilot.com/mcp"
+  headers:
+    - name: "Authorization"
+      value:
+        valueFrom:
+          secretKeyRef:
+            name: github-token
+            key: token
+    - name: "User-Agent"
+      value:
+        value: "mckinsey-agent/1.0"
+  timeout: "30s"
+  transport: http
+  description: "Remote GitHub MCP server hosted by GitHub"
+{{- end }}

--- a/demos/agentic-bus.md
+++ b/demos/agentic-bus.md
@@ -1,0 +1,11 @@
+## Integration to AWS Agentcore
+
+AWS Agentcore has many capabilities:
+
+ - AgentCore Runtime - Serverless deployment and scaling for dynamic AI agents
+ - AgentCore Memory - Persistent knowledge with event and semantic memory
+ - AgentCore Code Interpreter - Secure code execution in isolated sandboxes
+ - AgentCore Browser - Fast, secure cloud-based browser for web interaction
+ - AgentCore Gateway - Transform existing APIs into agent tools
+ - AgentCore Observability - Real-time monitoring and tracing
+ - AgentCore Identity - Secure authentication and access management

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,6 @@
+# notebooks
+
+```
+pip install jupyterlab
+jupyterlab
+```

--- a/notebooks/ark-openai-apis.ipynb
+++ b/notebooks/ark-openai-apis.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install OpenAI client if needed\n",
+    "!pip install openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "# Configure client for local endpoint\n",
+    "client = OpenAI(\n",
+    "    base_url=\"http://localhost:8080/v1\",  # Change port as needed\n",
+    "    api_key=\"dummy-key\"  # Local endpoints often don't need real keys\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List available models\n",
+    "models = client.models.list()\n",
+    "print(\"Available models:\")\n",
+    "for model in models.data:\n",
+    "    print(f\"- {model.id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Non-streaming completion\n",
+    "response = client.chat.completions.create(\n",
+    "    model=\"gpt-3.5-turbo\",  # Replace with actual model from list above\n",
+    "    messages=[\n",
+    "        {\"role\": \"user\", \"content\": \"Hello! How are you?\"}\n",
+    "    ],\n",
+    "    stream=False\n",
+    ")\n",
+    "\n",
+    "print(\"Non-streaming response:\")\n",
+    "print(response.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Streaming completion\n",
+    "stream = client.chat.completions.create(\n",
+    "    model=\"gpt-3.5-turbo\",  # Replace with actual model from list above\n",
+    "    messages=[\n",
+    "        {\"role\": \"user\", \"content\": \"Tell me a short story about a robot.\"}\n",
+    "    ],\n",
+    "    stream=True\n",
+    ")\n",
+    "\n",
+    "print(\"Streaming response:\")\n",
+    "for chunk in stream:\n",
+    "    if chunk.choices[0].delta.content is not None:\n",
+    "        print(chunk.choices[0].delta.content, end=\"\")\n",
+    "print()  # New line after streaming"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,7 @@ models:
 
   # Azure OpenAI provider
   azureOpenAI:
-    enabled: false  # Disabled to avoid creating default model
+    enabled: true
     apiKey: ""  # Set your Azure OpenAI API key here
     baseUrl: "https://lxo.openai.azure.com"
     apiVersion: "2024-12-01-preview"
@@ -54,6 +54,7 @@ agents:
     description: |
       I'm a code review specialist who helps improve code quality, identifies issues, and suggests improvements.
 
+
 # Team configuration
 teams:
   - name: coding-team
@@ -61,3 +62,27 @@ teams:
       - planner
       - code-reviewer
     strategy: sequential  # Options: simple, sequential
+
+# MCP Server configuration
+mcpServers:
+  github:
+    enabled: true  # Set to false to disable GitHub MCP server
+    githubToken: ""  # Set your GitHub token here
+    agent:
+      enabled: true  # Set to false to disable GitHub agent
+      name: github-agent
+      model: default  # Uses default model configured in the system
+      dashboardIcon: "/icons/github.png"
+      description: |
+        I'm a GitHub specialist who can help you interact with GitHub repositories, issues, pull requests, and workflows.
+        
+        I have access to comprehensive GitHub tools including:
+        - Repository management (search, create, update files)
+        - Issue tracking (list, create, update, search issues and sub-issues)
+        - Pull request operations (create, review, merge, get diffs and files)
+        - Workflow automation (list, run, rerun workflows and artifacts)  
+        - Code scanning and security (alerts, advisories)
+        - Discussions, gists, releases, and tags
+        - Team and organization management
+        
+        Simply ask me to help with any GitHub-related task and I'll use the appropriate tools to assist you.


### PR DESCRIPTION
## Summary
- Add GitHub MCP server configuration pointing to GitHub Copilot's remote MCP endpoint
- Create GitHub agent with all 87 available GitHub tools for comprehensive repository management  
- Add race condition handling in Makefile to ensure MCP server creates tools before agent deployment

## Key Features
- **GitHub MCP Server**: Connects to `https://api.githubcopilot.com/mcp` with proper authentication
- **Comprehensive GitHub Agent**: Has access to all 87 GitHub tools including:
  - Repository management (create, fork, branches, files)
  - Issues and pull requests (create, update, merge, review) 
  - Workflows and jobs (run, rerun, logs, artifacts)
  - Security scanning (alerts, advisories, dependabot)
  - Code search and organization management
- **Race Condition Fix**: Makefile now waits 15 seconds after MCP server deployment for tool enumeration
- **Clean Organization**: Templates organized in `github-mcp-agent/` subdirectory

## Configuration
- Both MCP server and agent enabled by default in values.yaml
- Configurable via `mcpServers.github.enabled` and `mcpServers.github.agent.enabled` 
- Requires `GITHUB_TOKEN` environment variable

## Test plan
- [ ] Deploy with `make install` and verify MCP server is created
- [ ] Verify GitHub tools are enumerated after 15 second wait
- [ ] Verify GitHub agent is created with all 87 tools in Phase 2
- [ ] Test agent can perform GitHub operations through MCP server