### PR TITLE
fix: update pr-review workflow for minio tls and tool names

### DIFF
--- a/demos/pr-review-workflow/pr-review-agent.yaml
+++ b/demos/pr-review-workflow/pr-review-agent.yaml
@@ -228,5 +228,5 @@ spec:
     type: custom
   - name: github-update-pull-request-branch
     type: custom
-  - name: shell-execute-shell-command
+  - name: shell-mcp-execute-shell-command
     type: custom

--- a/demos/pr-review-workflow/pr-review-workflow.yaml
+++ b/demos/pr-review-workflow/pr-review-workflow.yaml
@@ -73,7 +73,7 @@ spec:
         echo "checking workflow pvc '${pvc_name}'..."
         kubectl get pvc "${pvc_name}"
 
-        mcp_servers="github shell"
+        mcp_servers="github shell-mcp"
         for mcp_server in ${mcp_servers}; do
           echo "checking mcp server '${mcp_server}'..."
           kubectl get mcpserver "${mcp_server}"
@@ -147,6 +147,8 @@ spec:
       artifacts:
       - name: pr-list
         path: /tmp/pr-list.json
+        archive:
+          none: {}  # Store uncompressed for easy viewing in Argo UI
 
   - name: review-pr
     metadata:
@@ -238,6 +240,8 @@ spec:
       artifacts:
       - name: review
         path: /tmp/review-summary.txt
+        archive:
+          none: {}
 
   - name: summarize-reviews
     metadata:
@@ -272,3 +276,5 @@ spec:
       artifacts:
       - name: summary
         path: /tmp/summary.txt
+        archive:
+          none: {}


### PR DESCRIPTION
## Summary
- Fixes agent tool name to match actual tool created by shell-mcp
- Fixes workflow validation to check for shell-mcp MCPServer
- Configures MinIO artifact storage with proper TLS settings
- Uses full DNS name for certificate validation
- Stores artifacts uncompressed for easy viewing in Argo UI
- Makes namespace dynamic in artifact repository config

## Changes
- **Agent**: Changed tool name from `shell-execute-shell-command` to `shell-mcp-execute-shell-command`
- **Workflow**: Changed MCPServer validation from `shell` to `shell-mcp`
- **MinIO Config**: 
  - Use `minio.${namespace}.svc.cluster.local:443` endpoint
  - Set `insecure: false` with `caSecret` for proper TLS validation
  - Added `archive: none` to artifacts for easy viewing